### PR TITLE
feat(heating-mode): enable setting of the mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ecodan-ha-local/build/
+.vscode

--- a/ecodan-ha-local/ehal_hp.cpp
+++ b/ecodan-ha-local/ehal_hp.cpp
@@ -385,6 +385,38 @@ namespace ehal::hp
         return true;
     }
 
+    bool set_heating_mode(String mode)
+    {
+        Status::ShMode heatingMode = Status::ShMode::COMPENSATION_CURVE;
+
+        if (mode == "target_temperature")
+            heatingMode = Status::ShMode::TEMPERATURE;
+        else if (mode == "flow_control")
+            heatingMode = Status::ShMode::FLOW_CONTROL;
+        else if (mode == "compensation_curve")
+            heatingMode = Status::ShMode::COMPENSATION_CURVE;
+        else
+            return false;
+
+        Message cmd{MsgType::SET_CMD, SetType::BASIC_SETTINGS};
+        cmd[1] = SET_SETTINGS_FLAG_HEATING_MODE;
+        // Zone 1 is command 6
+        cmd[6] = static_cast<uint8_t>(heatingMode);
+
+        {
+            std::lock_guard<std::mutex>{cmdQueueMutex};
+            cmdQueue.emplace(std::move(cmd));
+        }
+
+        if (!dispatch_next_cmd())
+        {
+            log_web(F("command dispatch failed for heating mode setting!"));
+            return false;
+        }
+
+        return true;
+    }
+
     bool set_mode(const String& mode)
     {
         return true;

--- a/ecodan-ha-local/ehal_hp.h
+++ b/ecodan-ha-local/ehal_hp.h
@@ -224,6 +224,7 @@ namespace ehal::hp
     bool set_dhw_target_temperature(float value);
     bool set_dhw_mode(String mode);
     bool set_dhw_force(bool on);
+    bool set_heating_mode(String mode);
     bool set_mode(const String& mode);
 
     bool begin_connect();


### PR DESCRIPTION
This enables setting the heating mode through home assistant.

It currently does not work, even though according to https://github.com/m000c400/Mitsubishi-CN105-Protocol-Decode#0x32---set-options the command thould be available.

Feel free to push to this PR if you have an idea on how to get this working!