### PR TITLE
Add configuration parameter to be able to set the unique id part in HA

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Some parameters of your Mitsubishi Ecodan HVAC
 | ----------- | ------------| -------- |
 | `Cool enabled` | Check this option if your ecodan has cool working mode. Enable setting cool mode from Home Assistant | False |
 
+### Device Unique Identifier
+
+| Parameter   | Description | Default  |
+| ----------- | ------------| -------- |
+| `Unique Id` | Identifier to be used in Home Assistant sensors for this device. It should be unique for each Ecodan HVAC in the network. | False (It uses MAC address by default) |
+
+Changing the defaul value can be used to replace the ESP device without having to reconfigure the entities in Home Assistant or the software reading the MQTT messages and writing the values in influxdb.
+
 ### Dump Serial Packets
 Dump packets sent to/received from the heat pump to the diagnostic log window on the Diagnostics page.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Some parameters of your Mitsubishi Ecodan HVAC
 | ----------- | ------------| -------- |
 | `Unique Id` | Identifier to be used in Home Assistant sensors for this device. It should be unique for each Ecodan HVAC in the network. | False (It uses MAC address by default) |
 
-Changing the defaul value can be used to replace the ESP device without having to reconfigure the entities in Home Assistant or the software reading the MQTT messages and writing the values in influxdb.
+Changing the default value can be used to replace the ESP device without having to reconfigure the entities in Home Assistant or the software reading the MQTT messages and writing the values in influxdb.
 
 ### Dump Serial Packets
 Dump packets sent to/received from the heat pump to the diagnostic log window on the Diagnostics page.

--- a/ecodan-ha-local/ehal_config.cpp
+++ b/ecodan-ha-local/ehal_config.cpp
@@ -1,4 +1,6 @@
 #include "ehal_config.h"
+#include "ehal.h"
+#include <WiFi.h>
 
 #include <Preferences.h>
 
@@ -26,6 +28,7 @@ namespace ehal
         config.StatusLed = prefs.getUShort("status_led", LED_BUILTIN);
         config.DumpPackets = prefs.getBool("dump_pkt", false);
         config.CoolEnabled = prefs.getBool("cool_enabled", false);
+        config.UniqueId = prefs.getString("unique_id", device_mac());
         config.WifiReset = prefs.getBool("wifi_reset", true);
         config.HostName = prefs.getString("hostname", "ecodan_ha_local");
         config.WifiSsid = prefs.getString("wifi_ssid");
@@ -52,6 +55,7 @@ namespace ehal
         prefs.putUShort("status_led", config.StatusLed);
         prefs.putBool("dump_pkt", config.DumpPackets);
         prefs.putBool("cool_enabled", config.CoolEnabled);
+        prefs.putString("unique_id", config.UniqueId);
         prefs.putBool("wifi_reset", config.WifiReset);
         prefs.putString("wifi_ssid", config.WifiSsid);
         prefs.putString("wifi_pw", config.WifiPassword);
@@ -84,7 +88,7 @@ namespace ehal
 
     String get_software_version()
     {
-        return FPSTR("v0.1.7");
+        return FPSTR("v0.1.8");
     }
 
 } // namespace ehal

--- a/ecodan-ha-local/ehal_config.cpp
+++ b/ecodan-ha-local/ehal_config.cpp
@@ -1,6 +1,5 @@
 #include "ehal_config.h"
 #include "ehal.h"
-#include <WiFi.h>
 
 #include <Preferences.h>
 

--- a/ecodan-ha-local/ehal_config.h
+++ b/ecodan-ha-local/ehal_config.h
@@ -13,6 +13,7 @@ namespace ehal
         uint16_t StatusLed;
         bool DumpPackets;
         bool CoolEnabled;
+        String UniqueId;
         bool WifiReset;
         String WifiSsid;
         String WifiPassword;

--- a/ecodan-ha-local/ehal_html.h
+++ b/ecodan-ha-local/ehal_html.h
@@ -80,6 +80,12 @@ namespace ehal
         <input class="column column-75" type="checkbox" id="cool_enabled" name="cool_enabled" {{cool_enabled}} />
     </div>
     <br />
+    <h2>Device Unique id</h2>
+    <div class="row">
+        <label class="column column-25" for="unique_id">Device Unique Id:</label>
+        <input class="column column-75" type="text" id="unique_id" max-length="11" name="unique_id" value="{{unique_id}}" />
+    </div>
+    <br />
     <h2>WiFi Configuration:</h2>
     <div class="row">
         <label  class="column column-25" for="wifi_ssid">WiFi SSID:</label>

--- a/ecodan-ha-local/ehal_http.cpp
+++ b/ecodan-ha-local/ehal_http.cpp
@@ -7,6 +7,7 @@
 #include "ehal_js.h"
 #include "ehal_mqtt.h"
 #include "ehal_thirdparty.h"
+#include "ehal.h"
 
 #include <DNSServer.h>
 #include <Update.h>
@@ -173,6 +174,11 @@ namespace ehal::http
         else
             page.replace(F("{{cool_enabled}}"), "");
 
+        if (config.UniqueId)
+            page.replace(F("{{unique_id}}"), config.UniqueId);
+        else
+            page.replace(F("{{unique_id}}"), device_mac());
+
         page.replace(F("{{wifi_ssid}}"), config.WifiSsid);
         page.replace(F("{{wifi_pw}}"), config.WifiPassword);
         page.replace(F("{{hostname}}"), config.HostName);
@@ -217,6 +223,8 @@ namespace ehal::http
             config.WifiReset = true;
         else
             config.WifiReset = false;
+
+        config.UniqueId = server.arg(F("unique_id"));
 
         config.WifiSsid = server.arg(F("wifi_ssid"));
         config.WifiPassword = server.arg(F("wifi_pw"));

--- a/ecodan-ha-local/ehal_http.cpp
+++ b/ecodan-ha-local/ehal_http.cpp
@@ -174,7 +174,7 @@ namespace ehal::http
         else
             page.replace(F("{{cool_enabled}}"), "");
 
-        if (config.UniqueId)
+        if (config.UniqueId.length() > 0)
             page.replace(F("{{unique_id}}"), config.UniqueId);
         else
             page.replace(F("{{unique_id}}"), device_mac());

--- a/ecodan-ha-local/ehal_mqtt.cpp
+++ b/ecodan-ha-local/ehal_mqtt.cpp
@@ -407,7 +407,7 @@ off
 
     String unique_entity_name(const String& name)
     {
-        return name + "_" + device_mac();
+        return name + "_" + config_instance().UniqueId;
     }
 
     void add_discovery_device_object(JsonObject obj)


### PR DESCRIPTION
I made a change to be able to set the unique identifier part in sensors name in Home Assistant.

This can be useful in case you want to replace the ESP without having to reconfigure automations, etc in Home Assistant.

I tested the changes replacing my ESP with a new one and managing the device in Home Assistant as it was the old one.

Consider merging the code in case you think it could benefit anyone.

Thanks

Carlos