### PR TITLE
Add publish diagnostic sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Uses the CN105 connector on the Cased Flow Temp Controller (FTC6 in my setup) to
 - COP of space heating
 - COP of DHW
 
+## Diagnostic sensors retreived
+- Heat pump connection state
+- Wifi RSSI
+- Wifi SSID
+- IP address
+- MAC address
+
 <p float="left">
   <img src="img/config_page.png" height="640" />
   <img src="img/hp_state.png" height="640" />
@@ -147,7 +154,8 @@ Note: If this setting or "WiFi SSID" are unset, the device will continue to boot
 ### Auto-Reset WiFi Settings
 Some parameters of your Mitsubishi Ecodan HVAC
 | Description | Default  |
-| Check this option to fall back to broadcasting a "captive portal" WiFi access point if the network connection is lost for a long time (~20 mins). Intended to avoid the need for physically accessing the ESP32 if (e.g. a router is replaced, and the SSID / password are different). If a device password is set, a device password will be required to connect to the captive port access point. | False |
+| ----------- | -------- |
+| Check this option to fall back to broadcasting a "captive portal" WiFi access point if the network connection is lost for a long time (~20 mins). Intended to avoid the need for physically accessing the ESP32 if (e.g. a router is replaced, and the SSID / password are different). If a device password is set, a device password will be required to connect to the captive port access point. | `False` |
 
 ### Hostname
 The network hostname the device will use to identify itself.

--- a/ecodan-ha-local/ehal_config.cpp
+++ b/ecodan-ha-local/ehal_config.cpp
@@ -87,7 +87,7 @@ namespace ehal
 
     String get_software_version()
     {
-        return FPSTR("v0.1.8");
+        return FPSTR("v0.1.9");
     }
 
 } // namespace ehal

--- a/ecodan-ha-local/ehal_http.cpp
+++ b/ecodan-ha-local/ehal_http.cpp
@@ -339,7 +339,7 @@ namespace ehal::http
         page.replace(F("{{wifi_gateway_ip}}"), WiFi.gatewayIP().toString());
         page.replace(F("{{wifi_mac}}"), WiFi.macAddress());
         page.replace(F("{{wifi_mac}}"), WiFi.macAddress());
-        page.replace(F("{{wifi_tx_power}}"), String(WiFi.getTxPower()));
+        page.replace(F("{{wifi_tx_power}}"), String(WiFi.RSSI()));
         page.replace(F("{{device_boot_time}}"), ehal::config_instance().BootTime);
 
         page.replace(F("{{ha_hp_entity}}"), String(F("climate.")) + ehal::mqtt::unique_entity_name(F("climate_control")));

--- a/ecodan-ha-local/ehal_mqtt.cpp
+++ b/ecodan-ha-local/ehal_mqtt.cpp
@@ -34,7 +34,12 @@ namespace ehal::mqtt
         FREQUENCY,
         TEMPERATURE,
         FLOW_RATE,
-        COP
+        COP,
+        CONNECTIVITY,
+        WIFI_SIGNAL,
+        WIFI_SSID,
+        IP_ADDRESS,
+        MAC_ADDRESS
     };
 
     // https://arduinojson.org/v6/how-to/configure-the-serialization-of-floats/#how-to-reduce-the-number-of-decimal-places
@@ -407,7 +412,9 @@ off
 
     String unique_entity_name(const String& name)
     {
-        return name + "_" + device_mac();
+        String stringName = name;
+        stringName.replace(" ", "_");
+        return  stringName + "_" + device_mac();
     }
 
     void add_discovery_device_object(JsonObject obj)
@@ -802,6 +809,64 @@ off
         return true;
     }
 
+    bool publish_ha_diagnostic_sensor_auto_discover(const String& name, SensorType type)
+    {
+        const auto& config = config_instance();
+        String uniqueName = unique_entity_name(name);
+        String discoveryTopic = String(F("homeassistant/sensor/")) + uniqueName + F("/config");
+        String stateTopic = config.MqttTopic + "/" + uniqueName + F("/state");
+
+        // https://www.home-assistant.io/integrations/sensor.mqtt/
+        JsonDocument doc;
+        JsonObject payloadJson = doc.to<JsonObject>();
+        payloadJson[F("name")] = name;
+        payloadJson[F("unique_id")] = uniqueName;
+
+        add_discovery_device_object(payloadJson);
+
+        payloadJson[F("entity_category")] = "diagnostic";
+        payloadJson[F("stat_t")] = stateTopic;
+        payloadJson[F("val_tpl")] = F("{{ value }}");
+        payloadJson[F("exp_aft")] = SENSOR_STATE_TIMEOUT;
+
+        switch (type)
+        {
+        case SensorType::CONNECTIVITY:
+            discoveryTopic = String(F("homeassistant/binary_sensor/")) + uniqueName + F("/config");
+            payloadJson[F("payload_off")] = F("off");
+            payloadJson[F("payload_on")] = F("on");
+            payloadJson[F("dev_cla")] = F("connectivity");
+            break;
+        case SensorType::WIFI_SIGNAL:
+            payloadJson[F("unit_of_meas")] = F("dBm");
+            payloadJson[F("icon")] = F("mdi:wifi");
+            payloadJson[F("dev_cla")] = F("signal_strength");
+            break;
+        case SensorType::WIFI_SSID:
+            payloadJson[F("icon")] = F("mdi:eye");
+            payloadJson[F("enabled_by_default")] = bool(false);
+            break;
+        case SensorType::IP_ADDRESS:
+            payloadJson[F("icon")] = F("mdi:ip");
+            payloadJson[F("enabled_by_default")] = bool(false);
+            break;
+        case SensorType::MAC_ADDRESS:
+            payloadJson[F("icon")] = F("mdi:eye");
+            payloadJson[F("enabled_by_default")] = bool(false);            
+            break;
+        default:
+            break;
+        }
+
+        if (!publish_mqtt(discoveryTopic, doc))
+        {
+            log_web(F("Failed to publish homeassistant %s entity auto-discover"), uniqueName.c_str());
+            return false;
+        }
+
+        return true;
+    }
+
     void publish_homeassistant_auto_discover()
     {
         if (!needsAutoDiscover)
@@ -926,6 +991,22 @@ off
 
         if (!publish_ha_float_sensor_auto_discover(F("sh_cop"), SensorType::COP))
             anyFailed = true;
+        
+        // Diagnostic sensors
+        if (!publish_ha_diagnostic_sensor_auto_discover(F("Heat pump connection state"), SensorType::CONNECTIVITY))
+            anyFailed = true;
+        
+        if (!publish_ha_diagnostic_sensor_auto_discover(F("Wifi signal"), SensorType::WIFI_SIGNAL))
+            anyFailed = true;
+        
+        if (!publish_ha_diagnostic_sensor_auto_discover(F("Wifi SSID"), SensorType::WIFI_SSID))
+            anyFailed = true;
+
+        if (!publish_ha_diagnostic_sensor_auto_discover(F("IP address"), SensorType::IP_ADDRESS))
+            anyFailed = true;
+
+        if (!publish_ha_diagnostic_sensor_auto_discover(F("MAC address"), SensorType::MAC_ADDRESS))
+            anyFailed = true;
 
         if (!anyFailed)
             needsAutoDiscover = false;
@@ -1013,6 +1094,13 @@ off
         publish_sensor_status<float>(F("dhw_temp"), status.DhwTemperature);
         publish_sensor_status<float>(F("dhw_cop"), status.EnergyConsumedDhw > 0.0f ? status.EnergyDeliveredDhw / status.EnergyConsumedDhw : 0.0f);
         publish_sensor_status<float>(F("sh_cop"), status.EnergyConsumedHeating > 0.0f ? status.EnergyDeliveredHeating / status.EnergyConsumedHeating : 0.0f);
+        // Diagnostic
+        publish_binary_sensor_status(F("Heat pump connection state"), hp::is_connected());
+        publish_sensor_status<int>(F("Wifi signal"), int(WiFi.RSSI()));
+        publish_sensor_status<String>(F("Wifi SSID"), WiFi.SSID());
+        publish_sensor_status<String>(F("IP address"), WiFi.localIP().toString());
+        publish_sensor_status<String>(F("MAC address"), WiFi.macAddress());
+
     }
 
     bool connect()


### PR DESCRIPTION
Hi @rbroker, 

I´ve taken some time and implemented allow to publishing some diagnostic sensors.

- Heat pump connection status
- Wifi RSSI
- Wifi SSID
- IP address
- Mac address

![image](https://github.com/rbroker/ecodan-ha-local/assets/14091407/43f80ac3-2804-4e2d-a346-52de09a0f599)

Also, I fixed getting value of wifi tx power. Always show 78. Now show a real tx.