### PR TITLE
Flush port after write

### DIFF
--- a/ecodan-ha-local/ehal_hp.cpp
+++ b/ecodan-ha-local/ehal_hp.cpp
@@ -42,6 +42,7 @@ namespace ehal::hp
 
         msg.set_checksum();
         port.write(msg.buffer(), msg.size());
+	port.flush();
 
         auto& config = config_instance();
         if (config.DumpPackets)


### PR DESCRIPTION
I have an automation that sets the tank setpoint to 55c when the legionella prevention starts. This automation sends a mqtt command on state change of the operation mode. The command gets lost when there's communication going on (reading other status info).

If we flush the port after a write, then the problem is fixed. 
see: https://www.arduino.cc/reference/tr/language/functions/communication/serial/flush/