### PR TITLE
Add second climate entity for Zone 2

### DIFF
--- a/ecodan-ha-local/ehal_config.cpp
+++ b/ecodan-ha-local/ehal_config.cpp
@@ -87,7 +87,7 @@ namespace ehal
 
     String get_software_version()
     {
-        return FPSTR("v0.2.2");
+        return FPSTR("v0.2.3");
     }
 
 } // namespace ehal

--- a/ecodan-ha-local/ehal_hp.h
+++ b/ecodan-ha-local/ehal_hp.h
@@ -249,6 +249,8 @@ namespace ehal::hp
 
     bool set_z1_target_temperature(float value);
     bool set_z1_flow_target_temperature(float value);
+    bool set_z2_target_temperature(float value);
+    bool set_z2_flow_target_temperature(float value);
     bool set_dhw_target_temperature(float value);
     bool set_dhw_mode(String mode);
     bool set_dhw_force(bool on);

--- a/ecodan-ha-local/ehal_html.h
+++ b/ecodan-ha-local/ehal_html.h
@@ -235,8 +235,12 @@ namespace ehal
         <td>{{device_boot_time}}</td>
     </tr>
     <tr>
-        <td>HomeAssistant Heat Pump Entity:</td>
+        <td>HomeAssistant Heat Pump Zone 1 Entity:</td>
         <td>{{ha_hp_entity}}</td>
+    </tr>
+    <tr>
+        <td>HomeAssistant Heat Pump Zone 2 Entity:</td>
+        <td>{{ha_hp_z2_entity}}</td>
     </tr>
     <tr>
         <td>Heat Pump Message Tx Count:</td>

--- a/ecodan-ha-local/ehal_http.cpp
+++ b/ecodan-ha-local/ehal_http.cpp
@@ -352,6 +352,7 @@ namespace ehal::http
         page.replace(F("{{device_boot_time}}"), ehal::config_instance().BootTime);
 
         page.replace(F("{{ha_hp_entity}}"), String(F("climate.")) + ehal::mqtt::unique_entity_name(F("climate_control")));
+        page.replace(F("{{ha_hp_z2_entity}}"), String(F("climate.")) + ehal::mqtt::unique_entity_name(F("climate_control_z2")));
 
         page.replace(F("{{hp_tx_count}}"), uint64_to_string(hp::get_tx_msg_count()));
         page.replace(F("{{hp_rx_count}}"), uint64_to_string(hp::get_rx_msg_count()));


### PR DESCRIPTION
The documented flag for Zone 2 does not work and resets the Zone1 temperature to zero, therefore we use SetZone::BOTH as this seems to work correctly by setting Zone1 to it currently set value using register 10 and Zone2 to the new value using register 12.

![Animation](https://github.com/user-attachments/assets/095aaf1b-d3bb-4588-b4c0-2554505a6073)
